### PR TITLE
Cham 94 가족스페이스 보상내역 UI 및 완료 처리 구현 (새싹 다시 원래데로)

### DIFF
--- a/app/(app)/family-space/page.tsx
+++ b/app/(app)/family-space/page.tsx
@@ -1,23 +1,23 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
-import { useFamily } from '@/hooks/family';
-import { useAuth } from '@/hooks/useAuth';
-import { FamilySpaceHeader } from '@/components/family-space/FamilySpaceHeader';
-import { PlantSection } from '@/components/family-space/PlantSection';
-import { FamilyMemberSection } from '@/components/family-space/FamilyMemberSection';
-import { FamilyRecommendationCard } from '@/components/family-space/FamilyRecommendationCard';
-import { MessageCardSection } from '@/components/family-space/MessageCardSection';
-import { RewardHistorySection } from '@/components/family-space/RewardHistorySection';
-import { UIFamilyMember } from '@/types/family.type';
-import { plantApi } from '@/lib/api/plant';
-import { PlantStatus } from '@/types/plants.type';
-import { MessageCardModal } from '@/components/message-card-modal';
-import { useAddPoint } from '@/hooks/plant';
-import { usePlantStatus } from '@/hooks/plant/usePlantStatus';
-import { useUpdateFamilyName } from '@/hooks/family/useFamilyMutations';
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useFamily } from "@/hooks/family";
+import { useAuth } from "@/hooks/useAuth";
+import { FamilySpaceHeader } from "@/components/family-space/FamilySpaceHeader";
+import { PlantSection } from "@/components/family-space/PlantSection";
+import { FamilyMemberSection } from "@/components/family-space/FamilyMemberSection";
+import { FamilyRecommendationCard } from "@/components/family-space/FamilyRecommendationCard";
+import { MessageCardSection } from "@/components/family-space/MessageCardSection";
+import { RewardHistorySection } from "@/components/family-space/RewardHistorySection";
+import { UIFamilyMember } from "@/types/family.type";
+import { plantApi } from "@/lib/api/plant";
+import { PlantStatus } from "@/types/plants.type";
+import { MessageCardModal } from "@/components/message-card-modal";
+import { useAddPoint } from "@/hooks/plant";
+import { usePlantStatus } from "@/hooks/plant/usePlantStatus";
+import { useUpdateFamilyName } from "@/hooks/family/useFamilyMutations";
 
 declare global {
   interface Window {
@@ -93,22 +93,22 @@ export default function FamilySpacePage() {
           // 10초 후 타임아웃
           setTimeout(() => {
             clearInterval(checkLoaded);
-            reject(new Error('카카오 SDK 로드 타임아웃'));
+            reject(new Error("카카오 SDK 로드 타임아웃"));
           }, 10000);
           return;
         }
 
         // 스크립트 동적 로드
-        const script = document.createElement('script');
-        script.src = 'https://developers.kakao.com/sdk/js/kakao.js';
+        const script = document.createElement("script");
+        script.src = "https://developers.kakao.com/sdk/js/kakao.js";
         script.async = true;
         script.onload = () => {
-          console.log('✅ 카카오 SDK 스크립트 로드 완료');
+          console.log("✅ 카카오 SDK 스크립트 로드 완료");
           resolve();
         };
         script.onerror = () => {
-          console.error('❌ 카카오 SDK 스크립트 로드 실패');
-          reject(new Error('카카오 SDK 스크립트 로드 실패'));
+          console.error("❌ 카카오 SDK 스크립트 로드 실패");
+          reject(new Error("카카오 SDK 스크립트 로드 실패"));
         };
         document.head.appendChild(script);
       });
@@ -116,81 +116,69 @@ export default function FamilySpacePage() {
 
     const initKakao = async () => {
       try {
-        console.log('🔍 카카오 SDK 초기화 시도:', {
-          windowExists: typeof window !== 'undefined',
-          windowKakao: typeof window !== 'undefined' ? !!window.Kakao : false,
+        console.log("🔍 카카오 SDK 초기화 시도:", {
+          windowExists: typeof window !== "undefined",
+          windowKakao: typeof window !== "undefined" ? !!window.Kakao : false,
           isInitialized:
-            typeof window !== 'undefined' && window.Kakao ? window.Kakao.isInitialized() : false,
+            typeof window !== "undefined" && window.Kakao ? window.Kakao.isInitialized() : false,
           jsKey: process.env.NEXT_PUBLIC_KAKAO_JS_KEY,
         });
 
         // SDK 로드 대기
         await loadKakaoSDK();
 
-        if (typeof window !== 'undefined' && window.Kakao && !window.Kakao.isInitialized()) {
-          console.log('✅ 카카오 SDK 초기화 실행');
+        if (typeof window !== "undefined" && window.Kakao && !window.Kakao.isInitialized()) {
+          console.log("✅ 카카오 SDK 초기화 실행");
           window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
-          console.log('✅ 카카오 SDK 초기화 완료');
+          console.log("✅ 카카오 SDK 초기화 완료");
         }
       } catch (error) {
-        console.error('❌ 카카오 SDK 초기화 실패:', error);
+        console.error("❌ 카카오 SDK 초기화 실패:", error);
       }
     };
 
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       initKakao();
     }
   }, []);
 
-  const calculateDaysAfterFamilyCreation = (): number => {
+  const daysAfterFamilyCreation = (() => {
     if (family?.family?.daysAfterCreation !== undefined) {
       return family.family.daysAfterCreation;
     }
-
     if (family?.family?.createdAt) {
       const createdAt = new Date(family.family.createdAt);
       const today = new Date();
-
-      // 시간을 제거하고 날짜만 비교
       const createdDate = new Date(
         createdAt.getFullYear(),
         createdAt.getMonth(),
         createdAt.getDate()
       );
       const todayDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-
       const diffTime = todayDate.getTime() - createdDate.getTime();
       const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-      return Math.max(0, diffDays); // 음수가 나오지 않도록 보장
+      return Math.max(0, diffDays);
     }
-
     return 0;
-  };
-
-  const daysAfterFamilyCreation = calculateDaysAfterFamilyCreation();
+  })();
 
   const plantType = family?.plant?.plantType; // "flower" or "tree"
-
   const plantImage =
-    plantType === 'tree' ? '/public/images/tree1.png' : '/public/images/flower1.png';
-
-  <img src={plantImage} alt="식물 이미지" />;
+    plantType === "tree" ? "/public/images/tree1.png" : "/public/images/flower1.png";
 
   const handlePlantAction = () => {
     // 2인 이상 체크
     if (memberCount < 2) {
-      toast.error('2인 이상부터 새싹을 만들 수 있어요! 가족을 더 초대해보세요.');
+      toast.error("2인 이상부터 새싹을 만들 수 있어요! 가족을 더 초대해보세요.");
       return;
     }
-    //레벨 5 && 미완료 시에도 plant-game 으로 이동
+    // 식물 상태(react-query) 기준으로 분기
     if (plantStatus && !plantStatus.completed) {
-      router.push('/plant-game');
+      router.push("/plant-game");
       return;
     }
-
     // 완료됐거나 없으면 생성 화면으로
-    router.push('/plant-selection');
+    router.push("/plant-selection");
   };
 
   const handleCopyCode = async () => {
@@ -199,10 +187,10 @@ export default function FamilySpacePage() {
     try {
       await navigator.clipboard.writeText(family.family.inviteCode);
       setCopied(true);
-      toast.success('초대 코드가 복사되었습니다! 가족들에게 공유해보세요.');
+      toast.success("초대 코드가 복사되었습니다! 가족들에게 공유해보세요.");
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      toast.error('복사에 실패했습니다');
+      toast.error("복사에 실패했습니다");
     }
   };
 
@@ -212,7 +200,7 @@ export default function FamilySpacePage() {
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || window.location.origin;
     const imageUrl = `${baseUrl}/images/modi-logo-small.png`;
 
-    console.log('🔍 카카오 공유 시도:', {
+    console.log("🔍 카카오 공유 시도:", {
       windowKakao: !!window.Kakao,
       isInitialized: window.Kakao?.isInitialized?.(),
       familyName: family.family.name,
@@ -222,34 +210,34 @@ export default function FamilySpacePage() {
 
     // 카카오톡 공유만 사용하고 브라우저 공유 기능은 제거
     if (window.Kakao && window.Kakao.isInitialized()) {
-      console.log('✅ 카카오 SDK 초기화됨, 공유 실행');
+      console.log("✅ 카카오 SDK 초기화됨, 공유 실행");
       window.Kakao.Link.sendDefault({
-        objectType: 'feed',
+        objectType: "feed",
         content: {
           title: `🌱 ${family.family.name} 가족 스페이스에 초대합니다!`,
           description: `함께 식물을 키우고 요금제도 절약해요!\n초대 코드: ${family.family.inviteCode}`,
           imageUrl: imageUrl,
           link: {
-            mobileWebUrl: 'https://modi.app',
-            webUrl: 'https://modi.app',
+            mobileWebUrl: "https://modi.app",
+            webUrl: "https://modi.app",
           },
         },
         buttons: [
           {
-            title: 'MODi에서 확인',
+            title: "MODi에서 확인",
             link: {
-              mobileWebUrl: 'https://modi.app',
-              webUrl: 'https://modi.app',
+              mobileWebUrl: "https://modi.app",
+              webUrl: "https://modi.app",
             },
           },
         ],
       });
     } else {
-      console.log('❌ 카카오 SDK 초기화 안됨, 클립보드 복사로 대체');
+      console.log("❌ 카카오 SDK 초기화 안됨, 클립보드 복사로 대체");
       // 카카오톡 SDK가 없는 경우 클립보드에 복사
       const shareText = `🌱 ${family.family.name} 가족 스페이스에 초대합니다!\n\n초대 코드: ${family.family.inviteCode}\n\n함께 식물을 키우고 요금제도 절약해요! 💚\n\nMODi: https://modi.app`;
       navigator.clipboard.writeText(shareText);
-      toast.success('공유 메시지가 복사되었습니다! 카카오톡에서 붙여넣기 해주세요.');
+      toast.success("공유 메시지가 복사되었습니다! 카카오톡에서 붙여넣기 해주세요.");
     }
   };
 
@@ -261,7 +249,7 @@ export default function FamilySpacePage() {
 
   const handleSaveFamilyName = (name: string) => {
     if (!familyId) {
-      toast.error('가족 ID를 찾을 수 없습니다.');
+      toast.error("가족 ID를 찾을 수 없습니다.");
       return;
     }
 
@@ -272,7 +260,7 @@ export default function FamilySpacePage() {
           toast.success(`가족명이 변경되었습니다! ✨ 새로운 가족명: ${name}`);
         },
         onError: (error) => {
-          toast.error('가족명 변경에 실패했습니다');
+          toast.error("가족명 변경에 실패했습니다");
         },
       }
     );
@@ -280,14 +268,14 @@ export default function FamilySpacePage() {
 
   const handleSendCard = (design: string, message: string) => {
     // 메시지 저장 로직...
-    addPoint({ activityType: 'emotion' });
+    addPoint({ activityType: "emotion" });
     setShowMessageModal(false);
   };
 
   const handleMessageCardCreated = () => {
     // 메시지 카드 생성 후 포인트 적립
-    addPoint({ activityType: 'emotion' });
-    toast.success('메시지 카드를 생성했습니다! 💌 경험치가 적립되었습니다.');
+    addPoint({ activityType: "emotion" });
+    toast.success("메시지 카드를 생성했습니다! 💌 경험치가 적립되었습니다.");
     setShowMessageCardCreator(false);
   };
 
@@ -300,9 +288,9 @@ export default function FamilySpacePage() {
     dashboard?.members?.map((member) => ({
       id: member.uid,
       name: member.name,
-      avatar: member.profileImage ? '👤' : '🐛', // 프로필 이미지가 있으면 기본 아바타, 없으면 랜덤
+      avatar: member.profileImage ? "👤" : "🐛", // 프로필 이미지가 있으면 기본 아바타, 없으면 랜덤
       profileImage: member.profileImage, // 카카오톡 프로필 이미지
-      plan: member.planSummary || '요금제 없음',
+      plan: member.planSummary || "요금제 없음",
       hasRecommendation: false, // TODO: 추천 시스템 연동 필요
     })) || [];
 
@@ -311,19 +299,19 @@ export default function FamilySpacePage() {
   // ==========================================
   useEffect(() => {
     if (error) {
-      toast.error('가족 정보를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.');
+      toast.error("가족 정보를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
   }, [error]);
 
   useEffect(() => {
     if (messageCardsError) {
-      toast.error('메시지 카드를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.');
+      toast.error("메시지 카드를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
   }, [messageCardsError]);
 
   useEffect(() => {
     if (plantStatusError) {
-      toast.error('식물 상태를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
+      toast.error("식물 상태를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
     }
   }, [plantStatusError]);
 
@@ -333,8 +321,8 @@ export default function FamilySpacePage() {
   useEffect(() => {
     // 로딩이 완료되고 가족이 없는 경우 family-space-intro로 리다이렉트
     if (!isLoading && !hasFamily) {
-      console.log('🔄 가족 스페이스가 없어서 family-space-intro로 리다이렉트');
-      router.push('/family-space-tutorial');
+      console.log("🔄 가족 스페이스가 없어서 family-space-intro로 리다이렉트");
+      router.push("/family-space-tutorial");
     }
   }, [isLoading, hasFamily, router]);
 
@@ -372,6 +360,7 @@ export default function FamilySpacePage() {
       {/* Plant Section */}
       <PlantSection
         plant={family?.plant || { hasPlant: false, canCreateNew: false }}
+        plantStatus={plantStatus}
         onPlantAction={handlePlantAction}
         familyNutrial={family?.family?.nutrial}
         familyDaysAfterCreation={family?.family?.daysAfterCreation}
@@ -383,8 +372,8 @@ export default function FamilySpacePage() {
           {/* Family Section */}
           <FamilyMemberSection
             members={transformedMembers}
-            inviteCode={family?.family?.inviteCode || ''}
-            familyName={family?.family?.name || ''}
+            inviteCode={family?.family?.inviteCode || ""}
+            familyName={family?.family?.name || ""}
             onGenerateCode={handleGenerateNewInviteCode}
             onCopyCode={handleCopyCode}
             onShareKakao={handleShareKakao}
@@ -402,7 +391,7 @@ export default function FamilySpacePage() {
             membersWithPlan={dashboard?.membersWithPlan}
             onViewRecommendation={() => {
               // TODO: 추천 페이지로 이동
-              toast.info('추천 페이지로 이동합니다. 곧 구현될 예정입니다.');
+              toast.info("추천 페이지로 이동합니다. 곧 구현될 예정입니다.");
             }}
           />
 

--- a/app/(app)/plant-game/page.tsx
+++ b/app/(app)/plant-game/page.tsx
@@ -1,41 +1,41 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useCallback } from 'react';
-import { Button } from '@/components/ui/button';
-import { AnimatePresence } from 'framer-motion';
-import { FamilyWateringStatus } from '@/components/plant-game/FamilyWateringStatus';
-import { PlantImageDisplay } from '@/components/plant-game/PlantImageDisplay';
-import { PlantProgressBar } from '@/components/plant-game/PlantProgressBar';
-import { PlantActionButtons } from '@/components/plant-game/PlantActionButtons';
-import { ClaimRewardButton } from '@/components/plant-game/ClaimRewardButton';
-import { RewardModal } from '@/components/plant-game/RewardModal';
-import { MissionSheet } from '@/components/plant-game/MissionSheet';
-import { Mission } from '@/types/plant-game.type';
-import { ArrowLeft, UserPlus } from 'lucide-react';
-import Link from 'next/link';
-import { useFamily, useMessageCardsManager } from '@/hooks/family';
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { AnimatePresence } from "framer-motion";
+import { FamilyWateringStatus } from "@/components/plant-game/FamilyWateringStatus";
+import { PlantImageDisplay } from "@/components/plant-game/PlantImageDisplay";
+import { PlantProgressBar } from "@/components/plant-game/PlantProgressBar";
+import { PlantActionButtons } from "@/components/plant-game/PlantActionButtons";
+import { ClaimRewardButton } from "@/components/plant-game/ClaimRewardButton";
+import { RewardModal } from "@/components/plant-game/RewardModal";
+import { MissionSheet } from "@/components/plant-game/MissionSheet";
+import { Mission } from "@/types/plant-game.type";
+import { ArrowLeft, UserPlus } from "lucide-react";
+import Link from "next/link";
+import { useFamily, useMessageCardsManager } from "@/hooks/family";
 import {
   useAddPoint,
   useCheckTodayActivity,
   usePlantStatus,
   useNutrientStatus,
   useClaimReward,
-} from '@/hooks/plant';
-import { toast } from 'sonner';
-import { useQueryClient } from '@tanstack/react-query';
-import { usePlantSocket } from '@/hooks/plant/usePlantSocket';
-import { ActivityType, PlantEventData, RewardHistory } from '@/types/plants.type';
-import { useAuth } from '@/hooks/useAuth';
-import { plantApi } from '@/lib/api/plant';
-import { FamilyMember } from '@/types/family.type';
-import { Sprout, TreePine } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import confetti from 'canvas-confetti';
-import { CardMatchingGame } from '@/components/plant-game/CardMatchingGame';
-import { useGenerateInviteCode, useUpdateFamilyName } from '@/hooks/family/useFamilyMutations';
-import { MessageCardCreator } from '@/components/family-space/MessageCardCreator';
-import { InviteCodeModal } from '@/components/family-space/InviteCodeModal';
-import { QuizPage } from '@/components/plant-game/QuizPage';
+} from "@/hooks/plant";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import { usePlantSocket } from "@/hooks/plant/usePlantSocket";
+import { ActivityType, PlantEventData, RewardHistory } from "@/types/plants.type";
+import { useAuth } from "@/hooks/useAuth";
+import { plantApi } from "@/lib/api/plant";
+import { FamilyMember } from "@/types/family.type";
+import { Sprout, TreePine } from "lucide-react";
+import { useRouter } from "next/navigation";
+import confetti from "canvas-confetti";
+import { CardMatchingGame } from "@/components/plant-game/CardMatchingGame";
+import { useGenerateInviteCode, useUpdateFamilyName } from "@/hooks/family/useFamilyMutations";
+import { MessageCardCreator } from "@/components/family-space/MessageCardCreator";
+import { InviteCodeModal } from "@/components/family-space/InviteCodeModal";
+import { QuizPage } from "@/components/plant-game/QuizPage";
 
 // ==========================================
 // 🎮 새싹 키우기 게임 메인 페이지
@@ -58,43 +58,51 @@ import { QuizPage } from '@/components/plant-game/QuizPage';
 const MISSIONS: Mission[] = [
   {
     id: 1,
-    title: '1일 1회 출석하기',
-    description: '매일 밤 12시에 다시 시작됩니다.',
-    icon: '✏️',
-    reward: '출석하기',
-    activityType: 'attendance',
+    title: "1일 1회 출석하기",
+    description: "매일 밤 12시에 다시 시작됩니다.",
+    icon: "✏️",
+    reward: "출석하기",
+    activityType: "attendance",
   },
   {
     id: 2,
-    title: '가족에게 메세지 남기기',
-    description: '사랑하는 가족에게 작은 한마디',
-    icon: '💌',
-    reward: '메세지 작성',
-    activityType: 'emotion',
+    title: "가족에게 메세지 남기기",
+    description: "사랑하는 가족에게 작은 한마디",
+    icon: "💌",
+    reward: "메세지 작성",
+    activityType: "emotion",
   },
   {
     id: 3,
-    title: '요금제 퀴즈 풀기',
-    description: '더 많은 할인이 기다릴지도?',
-    icon: '🎯',
-    reward: '퀴즈 풀기',
-    activityType: 'quiz',
+    title: "요금제 퀴즈 풀기",
+    description: "더 많은 할인이 기다릴지도?",
+    icon: "🎯",
+    reward: "퀴즈 풀기",
+    activityType: "quiz",
   },
   {
     id: 4,
-    title: '골라 골라 오늘의 요금제',
-    description: '카들르 맞히고 요금제를 알아봐!!',
-    icon: '🎲',
-    reward: '카드 맞히기',
-    activityType: 'lastleaf',
+    title: "골라 골라 오늘의 요금제",
+    description: "카들르 맞히고 요금제를 알아봐!!",
+    icon: "🎲",
+    reward: "카드 맞히기",
+    activityType: "lastleaf",
+  },
+  {
+    id: 5,
+    title: "가족 등록",
+    description: "가족 등록하고 더 많은 보상을 받아보세요!",
+    icon: "👨‍👩‍👧‍👦",
+    reward: "초대하기",
+    activityType: "register",
   },
   {
     id: 6,
-    title: '통신 성향 검사',
-    description: '나에게 맞는 통신 캐릭터는?',
-    icon: '💬',
-    reward: '검사하기',
-    activityType: 'survey',
+    title: "통신 성향 검사",
+    description: "나에게 맞는 통신 캐릭터는?",
+    icon: "💬",
+    reward: "검사하기",
+    activityType: "survey",
   },
 ];
 
@@ -106,13 +114,13 @@ function ChoiceModal({
   options,
   onSubmit,
   onClose,
-  direction = 'row',
+  direction = "row",
 }: {
   title: string;
   options: string[];
   onSubmit: (choice: string) => void;
   onClose: () => void;
-  direction?: 'row' | 'col';
+  direction?: "row" | "col";
 }) {
   const [selected, setSelected] = useState<string | null>(null);
 
@@ -120,12 +128,12 @@ function ChoiceModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
       <div className="bg-white rounded-xl p-6 w-80 flex flex-col items-center">
         <div className="text-lg font-bold mb-4">{title}</div>
-        <div className={`flex mb-4 gap-2 ${direction === 'row' ? 'flex-row' : 'flex-col'}`}>
+        <div className={`flex mb-4 gap-2 ${direction === "row" ? "flex-row" : "flex-col"}`}>
           {options.map((opt) => (
             <button
               key={opt}
               className={`px-4 py-2 rounded-lg border ${
-                selected === opt ? 'bg-blue-500 text-white' : 'bg-gray-100'
+                selected === opt ? "bg-blue-500 text-white" : "bg-gray-100"
               }`}
               onClick={() => setSelected(opt)}
             >
@@ -205,8 +213,8 @@ export default function PlantGamePage() {
   } = usePlantStatus(familyId ?? 0);
 
   // 오늘 활동 완료 여부 확인
-  const { data: checkAlreadyWatered } = useCheckTodayActivity('water');
-  const { data: checkAlreadyFed } = useCheckTodayActivity('nutrient');
+  const { data: checkAlreadyWatered } = useCheckTodayActivity("water");
+  const { data: checkAlreadyFed } = useCheckTodayActivity("nutrient");
   const { data: nutrientCount = 0 } = useNutrientStatus(); // 영양제 개수
 
   // 포인트 적립 및 보상 수령 API
@@ -250,7 +258,7 @@ export default function PlantGamePage() {
       const wateredIds = await plantApi.getWaterMembers(familyId);
       setWateredMemberIds(wateredIds);
     } catch (error) {
-      console.error('물주기 완료 구성원 조회 실패:', error);
+      console.error("물주기 완료 구성원 조회 실패:", error);
     }
   }, [familyId]);
 
@@ -274,12 +282,12 @@ export default function PlantGamePage() {
 
         // 레벨업 토스트 표시
         if (event.isLevelUp) {
-          toast.success('🎉 레벨업! 식물이 성장했습니다!');
+          toast.success("🎉 레벨업! 식물이 성장했습니다!");
         }
 
         // 활동 타입별 처리
         switch (event.type) {
-          case 'water':
+          case "water":
             // 현재 사용자의 활동인 경우에만 상태 변경
             if (event.name === user?.nickname) {
               setAlreadyWatered(true);
@@ -289,37 +297,37 @@ export default function PlantGamePage() {
             toast.success(`${event.name}님이 물을 주었습니다! 💧`);
             break;
 
-          case 'nutrient':
+          case "nutrient":
             // 현재 사용자의 활동인 경우에만 상태 변경
             if (event.name === user?.nickname) {
               setAlreadyFed(true);
             }
             // 영양제 사용 시 영양제 개수 감소 (서버에서 업데이트된 값으로 동기화)
-            queryClient.invalidateQueries({ queryKey: ['plant-status', familyId] });
+            queryClient.invalidateQueries({ queryKey: ["plant-status", familyId] });
             toast.success(`${event.name}님이 영양제를 주었습니다! 🌱`);
             break;
 
-          case 'quiz':
+          case "quiz":
             toast.success(`${event.name}님이 퀴즈를 완료했습니다! 🎯`);
             break;
 
-          case 'emotion':
+          case "emotion":
             toast.success(`${event.name}님이 감정을 기록했습니다! 😊`);
             break;
 
-          case 'attendance':
+          case "attendance":
             toast.success(`${event.name}님이 출석했습니다! 📅`);
             break;
 
-          case 'survey':
+          case "survey":
             toast.success(`${event.name}님이 설문을 완료했습니다! 📝`);
             break;
 
-          case 'lastleaf':
+          case "lastleaf":
             toast.success(`${event.name}님이 카드 맞히기를 달성했습니다! 🍃`);
             break;
 
-          case 'register':
+          case "register":
             toast.success(`${event.name}님이 가입했습니다! 🎉`);
             break;
 
@@ -342,22 +350,22 @@ export default function PlantGamePage() {
   const handleWatering = () => {
     // 중복 요청 방지
     if (isPending || alreadyWatered) {
-      toast.warning('오늘은 이미 물을 주었어요 💧');
+      toast.warning("오늘은 이미 물을 주었어요 💧");
       return;
     }
 
     setIsWatering(true);
 
     addPoint(
-      { activityType: 'water' },
+      { activityType: "water" },
       {
         onSuccess: () => {
-          toast.success('물주기 완료!');
+          toast.success("물주기 완료!");
           setAlreadyWatered(true);
           setTimeout(() => setIsWatering(false), 2000);
-          queryClient.invalidateQueries({ queryKey: ['activity', 'check-today', 'water'] });
+          queryClient.invalidateQueries({ queryKey: ["activity", "check-today", "water"] });
           // 식물 상태 업데이트를 위해 쿼리 무효화
-          queryClient.invalidateQueries({ queryKey: ['plant-status', familyId] });
+          queryClient.invalidateQueries({ queryKey: ["plant-status", familyId] });
           // 물주기 완료된 구성원 목록 업데이트
           fetchWateredMembers();
         },
@@ -379,7 +387,7 @@ export default function PlantGamePage() {
   const handleFeeding = async () => {
     // 중복 요청 방지
     if (isPending || alreadyFed) {
-      toast.warning('오늘은 이미 영양제를 주었어요 🌿');
+      toast.warning("오늘은 이미 영양제를 주었어요 🌿");
       return;
     }
 
@@ -388,13 +396,13 @@ export default function PlantGamePage() {
       const serverNutrientCount = await plantApi.getNutrients();
 
       if (serverNutrientCount <= 0) {
-        toast.warning('영양제가 부족합니다! 미션을 완료해서 영양제를 얻어보세요! 🎯');
+        toast.warning("영양제가 부족합니다! 미션을 완료해서 영양제를 얻어보세요! 🎯");
         return;
       }
     } catch (error) {
       // 서버 확인 실패 시 로컬 상태로 판단
       if (nutrientCount <= 0) {
-        toast.warning('영양제가 부족합니다! 미션을 완료해서 영양제를 얻어보세요! 🎯');
+        toast.warning("영양제가 부족합니다! 미션을 완료해서 영양제를 얻어보세요! 🎯");
         return;
       }
     }
@@ -402,16 +410,16 @@ export default function PlantGamePage() {
     setIsFeeding(true);
 
     addPoint(
-      { activityType: 'nutrient' },
+      { activityType: "nutrient" },
       {
         onSuccess: () => {
-          toast.success('영양제 주기 완료! 포인트 적립 ✅');
+          toast.success("영양제 주기 완료! 포인트 적립 ✅");
           setAlreadyFed(true);
           setTimeout(() => setIsFeeding(false), 2000);
-          queryClient.invalidateQueries({ queryKey: ['activity', 'check-today', 'nutrient'] });
-          queryClient.invalidateQueries({ queryKey: ['plant-status', familyId] });
+          queryClient.invalidateQueries({ queryKey: ["activity", "check-today", "nutrient"] });
+          queryClient.invalidateQueries({ queryKey: ["plant-status", familyId] });
           // 영양제 개수 업데이트를 위해 쿼리 무효화
-          queryClient.invalidateQueries({ queryKey: ['nutrient', 'stock'] });
+          queryClient.invalidateQueries({ queryKey: ["nutrient", "stock"] });
         },
         onError: (error) => {
           setIsFeeding(false);
@@ -468,12 +476,12 @@ export default function PlantGamePage() {
 
   // 미션별 오늘 완료 여부 (서버에서 확인)
   const missionTypes: ActivityType[] = [
-    'attendance',
-    'emotion',
-    'quiz',
-    'lastleaf',
-    'register',
-    'survey',
+    "attendance",
+    "emotion",
+    "quiz",
+    "lastleaf",
+    "register",
+    "survey",
   ];
   const missionQueries = missionTypes.map((type) => useCheckTodayActivity(type, { staleTime: 0 }));
   const missionCompletedMap = Object.fromEntries(
@@ -493,25 +501,25 @@ export default function PlantGamePage() {
    */
   const handleMissionClick = (activityType: ActivityType) => {
     if (missionCompletedMap[activityType]) {
-      toast('내일 다시');
+      toast("내일 다시");
       setShowMissions(false);
       return;
     }
 
     switch (activityType) {
-      case 'quiz':
+      case "quiz":
         setShowMissions(false);
         setShowQuizPage(true);
         break;
-      case 'lastleaf':
+      case "lastleaf":
         setShowMissions(false);
         setShowCardMatchingGame(true);
         break;
-      case 'emotion':
+      case "emotion":
         setShowMissions(false);
         setShowMessageCardCreator(true);
         break;
-      case 'register':
+      case "register":
         setShowMissions(false);
         setShowInviteCodeModal(true);
         break;
@@ -527,20 +535,20 @@ export default function PlantGamePage() {
 
   // 메시지 카드 생성 완료 핸들러
   const handleMessageCardCreated = () => {
-    addPoint({ activityType: 'emotion' });
-    toast.success('메시지 카드를 생성했습니다! 경험치가 적립되었습니다. 💌');
+    addPoint({ activityType: "emotion" });
+    toast.success("메시지 카드를 생성했습니다! 경험치가 적립되었습니다. 💌");
   };
 
   // 카드 게임 완료 핸들러
   const handleCardGameCompleted = () => {
-    addPoint({ activityType: 'lastleaf' });
-    toast.success('마지막 잎새를 찾았습니다! 경험치가 적립되었습니다. 🍃');
+    addPoint({ activityType: "lastleaf" });
+    toast.success("마지막 잎새를 찾았습니다! 경험치가 적립되었습니다. 🍃");
   };
 
   // 카카오톡 공유 핸들러
   const handleShareKakao = () => {
-    addPoint({ activityType: 'register' });
-    toast.success('가족을 초대했습니다! 경험치가 적립되었습니다. 👨‍👩‍👧‍👦');
+    addPoint({ activityType: "register" });
+    toast.success("가족을 초대했습니다! 경험치가 적립되었습니다. 👨‍👩‍👧‍👦");
   };
 
   // 초대 코드 복사 핸들러
@@ -550,10 +558,10 @@ export default function PlantGamePage() {
     try {
       await navigator.clipboard.writeText(family.family.inviteCode);
       setCopied(true);
-      toast.success('초대 코드가 복사되었습니다! 가족들에게 공유해보세요.');
+      toast.success("초대 코드가 복사되었습니다! 가족들에게 공유해보세요.");
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      toast.error('복사에 실패했습니다');
+      toast.error("복사에 실패했습니다");
     }
   };
 
@@ -566,7 +574,7 @@ export default function PlantGamePage() {
   // 가족명 저장 핸들러
   const handleSaveFamilyName = (name: string) => {
     if (!familyId) {
-      toast.error('가족 ID를 찾을 수 없습니다.');
+      toast.error("가족 ID를 찾을 수 없습니다.");
       return;
     }
 
@@ -577,7 +585,7 @@ export default function PlantGamePage() {
           toast.success(`가족명이 변경되었습니다! ✨ 새로운 가족명: ${name}`);
         },
         onError: (error) => {
-          toast.error('가족명 변경에 실패했습니다');
+          toast.error("가족명 변경에 실패했습니다");
         },
       }
     );
@@ -594,9 +602,9 @@ export default function PlantGamePage() {
   const transformedMembers = familyMembers.map((member) => ({
     id: member.uid,
     name: member.name,
-    avatar: member.profileImage || '👤', // 카카오 프로필 이미지 또는 기본 이모지
+    avatar: member.profileImage || "👤", // 카카오 프로필 이미지 또는 기본 이모지
     hasWatered: wateredMemberIds.includes(member.uid),
-    status: wateredMemberIds.includes(member.uid) ? '물주기 완료' : '',
+    status: wateredMemberIds.includes(member.uid) ? "물주기 완료" : "",
   }));
 
   // ==========================================
@@ -619,7 +627,7 @@ export default function PlantGamePage() {
   // 🎮 UI 렌더링
   // ==========================================
   return (
-    <div className="bg-gradient-to-b from-blue-100 to-blue-50 flex flex-col h-full overflow-hidden">
+    <div className="h-full bg-gradient-to-b from-blue-100 to-blue-50 max-w-md mx-auto flex flex-col overflow-hidden">
       {/* 📱 헤더 영역 */}
       <div className="flex items-center justify-between p-3 flex-shrink-0">
         <Link href="/family-space">
@@ -629,57 +637,48 @@ export default function PlantGamePage() {
         <div className="w-6 h-6"></div> {/* 헤더 균형을 위한 빈 공간 */}
       </div>
 
-      {/* 👨‍👩‍👧‍👦 가족 구성원 상태 & 액션 버튼들 */}
+      {/* 👨‍👩‍👧‍👦 가족 구성원 상태 */}
       {currentLevel !== 5 && (
-        <div className="flex items-start justify-between px-3 mb-4 flex-shrink-0">
-          <div className="flex-1 min-w-0">
-            <FamilyWateringStatus members={transformedMembers} />
-          </div>
+        <div className="flex-shrink-0 mb-4">
+          <FamilyWateringStatus members={transformedMembers} />
+        </div>
+      )}
 
-          {/* 가족 초대 버튼 */}
-          <div className="flex items-center gap-2 pl-4">
-            <Button
-              size="icon"
-              className="bg-green-500 text-white hover:bg-green-600 rounded-full w-10 h-10 p-0"
-              onClick={() => setShowInviteCodeModal(true)}
-            >
-              <UserPlus className="w-5 h-5" />
-            </Button>
-            <Button
-              className="bg-gray-200 text-gray-700 hover:bg-gray-300 rounded-full px-4 py-2 text-sm"
-              onClick={() => setShowMissions(true)}
-            >
-              미션하기
-            </Button>
-          </div>
+      {/* 🎯 미션하기 버튼 */}
+      {currentLevel !== 5 && (
+        <div className="flex justify-end mb-2 flex-shrink-0 mr-8">
+          <Button
+            className="bg-gray-200 text-gray-700 hover:bg-gray-300 rounded-full px-6 py-2 text-sm"
+            onClick={() => setShowMissions(true)}
+          >
+            미션하기
+          </Button>
         </div>
       )}
 
       {/* 🌱 식물 이미지 영역 */}
-      <div className="flex-1 flex items-center justify-center min-h-0">
-        {currentLevel === 5 ? (
-          <div className="flex items-center justify-center w-full h-full">
-            <PlantImageDisplay
-              selectedPlantType={plantStatus?.plantType}
-              currentLevel={currentLevel}
-              isWatering={isWatering}
-              isFeeding={isFeeding}
-            />
-          </div>
-        ) : (
-          <div className="flex items-center justify-center w-full h-full px-4">
-            <PlantImageDisplay
-              selectedPlantType={plantStatus?.plantType}
-              currentLevel={currentLevel}
-              isWatering={isWatering}
-              isFeeding={isFeeding}
-            />
-          </div>
-        )}
-      </div>
+      {currentLevel === 5 ? (
+        <div className="flex-1 flex items-center justify-center px-0 py-0 h-full w-full">
+          <PlantImageDisplay
+            selectedPlantType={plantStatus?.plantType}
+            currentLevel={currentLevel}
+            isWatering={isWatering}
+            isFeeding={isFeeding}
+          />
+        </div>
+      ) : (
+        <div className="flex-1 flex items-center justify-center px-4 h-full w-full">
+          <PlantImageDisplay
+            selectedPlantType={plantStatus?.plantType}
+            currentLevel={currentLevel}
+            isWatering={isWatering}
+            isFeeding={isFeeding}
+          />
+        </div>
+      )}
 
       {/* 🎮 게임 컨트롤 영역 */}
-      <div className="flex-shrink-0 p-3 bg-white/80 backdrop-blur-sm">
+      <div className="flex-shrink-0 p-3">
         {currentLevel === 5 ? (
           <div className="flex flex-col items-center gap-4">
             <div className="text-xl font-bold text-green-600">5레벨 달성!!!</div>
@@ -748,13 +747,14 @@ export default function PlantGamePage() {
       <InviteCodeModal
         isOpen={showInviteCodeModal}
         onOpenChange={setShowInviteCodeModal}
-        inviteCode={family?.family?.inviteCode || ''}
-        familyName={family?.family?.name || '우리 가족'}
+        inviteCode={family?.family?.inviteCode || ""}
+        familyName={family?.family?.name || "우리 가족"}
         onGenerateCode={handleGenerateNewInviteCode}
         onCopyCode={handleCopyCode}
+        onShareKakao={handleShareKakao}
         onSaveFamilyName={handleSaveFamilyName}
         copied={copied}
-        isLoading={isUpdatingFamilyName}
+        trigger={null}
       />
 
       {/* 🎯 퀴즈 페이지 */}
@@ -763,8 +763,8 @@ export default function PlantGamePage() {
           <QuizPage
             onBack={() => setShowQuizPage(false)}
             onQuizComplete={() => {
-              addPoint({ activityType: 'quiz' });
-              toast.success('퀴즈 완료! 경험치가 적립되었습니다. 🎯');
+              addPoint({ activityType: "quiz" });
+              toast.success("퀴즈 완료! 경험치가 적립되었습니다. 🎯");
               setShowQuizPage(false);
             }}
           />

--- a/components/family-space/PlantSection.tsx
+++ b/components/family-space/PlantSection.tsx
@@ -59,18 +59,23 @@ export function PlantSection({
       {!isPlantStatusLoading && (
         <Button
           onClick={onPlantAction}
-          disabled={!canCreateNew && !hasPlant}
+          disabled={isPlantStatusLoading || plantStatus == null || (!canCreateNew && !hasPlant)}
           className="bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-full px-8 py-3 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {!plantStatus || plantStatus.completed ? (
+          {isPlantStatusLoading || plantStatus == null ? (
             <>
-              <Sprout className="w-4 h-4 mr-2" />
-              새싹 만들기
+              <Sprout className="w-4 h-4 mr-2 animate-pulse" />
+              ...
             </>
-          ) : (
+          ) : !plantStatus.completed ? (
             <>
               <TreePine className="w-4 h-4 mr-2" />
               새싹 키우기
+            </>
+          ) : (
+            <>
+              <Sprout className="w-4 h-4 mr-2" />
+              새싹 만들기
             </>
           )}
         </Button>

--- a/components/family-space/RewardHistorySection.tsx
+++ b/components/family-space/RewardHistorySection.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useFamilyRewardHistory } from "@/hooks/plant/useFamilyRewardHistory";
 import { useMarkRewardAsUsed } from "@/hooks/plant/useMarkRewardAsUsed";
-import { Gift, Calendar, CheckCircle, Package } from "lucide-react";
-import { motion } from "framer-motion";
+import { Gift, Calendar, CheckCircle, Package, ChevronDown } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { RewardHistory } from "@/types/plants.type";
 import { toast } from "sonner";
 
@@ -16,6 +16,7 @@ export function RewardHistorySection() {
   const { mutate: markRewardAsUsed, isPending: isMarking } = useMarkRewardAsUsed();
   const [selectedReward, setSelectedReward] = useState<RewardHistory | null>(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
+  const [showAll, setShowAll] = useState(false);
 
   const handleRewardClick = (reward: RewardHistory) => {
     setSelectedReward(reward);
@@ -36,16 +37,17 @@ export function RewardHistorySection() {
     }
   };
 
+  const displayedRewards = showAll ? rewards : rewards?.slice(0, 1);
+
   if (isLoading) {
     return (
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Gift className="w-5 h-5 text-yellow-500" />
-            보상 히스토리
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Card className="bg-white dark:bg-gray-800 shadow-sm border-0 rounded-2xl">
+        <CardContent className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white">보상 히스토리</h2>
+            </div>
+          </div>
           <div className="text-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-500 mx-auto mb-4"></div>
             <p className="text-gray-600">보상 히스토리를 불러오는 중...</p>
@@ -57,14 +59,13 @@ export function RewardHistorySection() {
 
   if (error) {
     return (
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Gift className="w-5 h-5 text-yellow-500" />
-            보상 히스토리
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Card className="bg-white dark:bg-gray-800 shadow-sm border-0 rounded-2xl">
+        <CardContent className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white">보상 히스토리</h2>
+            </div>
+          </div>
           <div className="text-center py-8">
             <p className="text-gray-600">보상 히스토리를 불러올 수 없습니다.</p>
           </div>
@@ -75,14 +76,13 @@ export function RewardHistorySection() {
 
   if (!rewards || rewards.length === 0) {
     return (
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Gift className="w-5 h-5 text-yellow-500" />
-            보상 히스토리
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Card className="bg-white dark:bg-gray-800 shadow-sm border-0 rounded-2xl">
+        <CardContent className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white">보상 히스토리</h2>
+            </div>
+          </div>
           <div className="text-center py-8">
             <Gift className="w-12 h-12 text-gray-300 mx-auto mb-4" />
             <p className="text-gray-600">아직 받은 보상이 없습니다.</p>
@@ -95,104 +95,209 @@ export function RewardHistorySection() {
 
   return (
     <>
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Gift className="w-5 h-5 text-yellow-500" />
-            보상 히스토리 ({rewards.length}개)
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {rewards.map((reward, index) => {
-              const isUsed = reward.used;
-              return (
-                <motion.div
-                  key={reward.rewardLogId}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.1 }}
-                  className={`bg-gradient-to-r from-yellow-50 to-orange-50 border border-yellow-200 rounded-lg p-4 transition-all cursor-pointer hover:shadow-md hover:scale-[1.02] ${
-                    isUsed
-                      ? "opacity-60 bg-gradient-to-r from-gray-50 to-gray-100 border-gray-200"
-                      : ""
-                  }`}
-                  onClick={() => handleRewardClick(reward)}
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h4 className="font-semibold text-gray-900">{reward.rewardName}</h4>
-                        {isUsed && <CheckCircle className="w-4 h-4 text-green-500" />}
-                      </div>
-                      <p className="text-gray-600 text-sm mb-2">{reward.description}</p>
-                      <div className="flex items-center gap-1 text-xs text-gray-500">
-                        <Calendar className="w-3 h-3" />
-                        {new Date(reward.receivedAt).toLocaleDateString("ko-KR", {
-                          year: "numeric",
-                          month: "long",
-                          day: "numeric",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
-                      </div>
-                      {isUsed && (
-                        <div className="mt-2 text-sm text-green-600 font-medium">보상완료!</div>
-                      )}
-                    </div>
-                    <div className="text-2xl ml-4">{isUsed ? "📦" : "🎁"}</div>
-                  </div>
-                </motion.div>
-              );
-            })}
+      <Card className="bg-white dark:bg-gray-800 shadow-sm border-0 rounded-2xl">
+        <CardContent className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white">보상 히스토리</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {rewards.length}개의 보상을 받았어요
+              </p>
+            </div>
           </div>
+
+          <div className="space-y-3">
+            <AnimatePresence initial={false}>
+              {displayedRewards?.map((reward, index) => {
+                const isUsed = reward.used;
+                return (
+                  <motion.div
+                    key={reward.rewardLogId}
+                    layout
+                    initial={{ opacity: 0, y: -20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    <Card
+                      className={`transition-shadow dark:bg-gray-700 ${
+                        isUsed
+                          ? "opacity-60 cursor-not-allowed bg-gray-100 dark:bg-gray-600"
+                          : "cursor-pointer hover:shadow-md"
+                      }`}
+                      onClick={() => !isUsed && handleRewardClick(reward)}
+                    >
+                      <CardContent className="p-4">
+                        <div className="flex items-center gap-2 mb-2">
+                          <Gift
+                            className={`w-5 h-5 ${isUsed ? "text-gray-400" : "text-yellow-500"}`}
+                          />
+                          <h3
+                            className={`font-semibold flex-1 ${
+                              isUsed
+                                ? "text-gray-500 dark:text-gray-400"
+                                : "text-gray-900 dark:text-white"
+                            }`}
+                          >
+                            {reward.rewardName}
+                          </h3>
+                          {isUsed && <CheckCircle className="w-4 h-4 text-green-500" />}
+                        </div>
+                        <p
+                          className={`text-sm mb-2 ${
+                            isUsed
+                              ? "text-gray-400 dark:text-gray-500"
+                              : "text-gray-600 dark:text-gray-300"
+                          }`}
+                        >
+                          {reward.description}
+                        </p>
+                        <div className="flex items-center justify-between text-xs text-gray-400">
+                          <div className="flex items-center gap-1">
+                            <Calendar className="w-3 h-3" />
+                            {new Date(reward.receivedAt).toLocaleDateString("ko-KR")}
+                          </div>
+                          <div className="text-2xl">{isUsed ? "📦" : "🎁"}</div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                );
+              })}
+            </AnimatePresence>
+          </div>
+
+          {rewards.length > 1 && (
+            <div className="mt-4 text-center">
+              <Button
+                variant="ghost"
+                onClick={() => setShowAll(!showAll)}
+                className="text-sm text-gray-500 hover:bg-transparent hover:text-yellow-600 dark:text-gray-400 dark:hover:bg-transparent dark:hover:text-yellow-400"
+              >
+                <motion.div animate={{ rotate: showAll ? 180 : 0 }} transition={{ duration: 0.3 }}>
+                  <ChevronDown className="w-4 h-4 mr-1" />
+                </motion.div>
+                {showAll ? "숨기기" : `최근 보상 ${rewards.length - 1}개 더보기`}
+              </Button>
+            </div>
+          )}
         </CardContent>
       </Card>
 
       {/* 보상 상세 모달 */}
       <Dialog open={showDetailModal} onOpenChange={setShowDetailModal}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Package className="w-5 h-5 text-yellow-500" />
-              보상 상세
-            </DialogTitle>
-          </DialogHeader>
+        <DialogContent className="sm:max-w-md p-0 overflow-hidden">
           {selectedReward && (
-            <div className="space-y-4">
-              <div className="text-center">
-                <div className="text-4xl mb-4">{selectedReward.used ? "📦" : "🎁"}</div>
-                <h3 className="text-xl font-bold text-gray-900 mb-2">
+            <div className="bg-white dark:bg-gray-800">
+              {/* 기프티콘 헤더 */}
+              <div className="bg-gradient-to-b from-blue-100 to-blue-50 dark:from-gray-700 dark:to-gray-600 p-6 text-center relative">
+                <div className="text-4xl mb-2">{selectedReward.used ? "📦" : "🎁"}</div>
+                <h3 className="text-xl font-bold text-gray-800 dark:text-white mb-1">
                   {selectedReward.rewardName}
                 </h3>
-                <p className="text-gray-600 mb-4">{selectedReward.description}</p>
-                <div className="flex items-center justify-center gap-1 text-sm text-gray-500 mb-4">
-                  <Calendar className="w-4 h-4" />
-                  {new Date(selectedReward.receivedAt).toLocaleDateString("ko-KR", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
+                <p className="text-gray-600 dark:text-gray-300 text-sm">
+                  {selectedReward.description}
+                </p>
+              </div>
+
+              {/* 기프티콘 바디 */}
+              <div className="p-6">
+                {/* 바코드 영역 */}
+                <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4 mb-4 text-center shadow-sm">
+                  <div className="text-xs text-gray-500 mb-2">바코드</div>
+                  <div className="flex justify-center items-center space-x-1 mb-2">
+                    {Array.from({ length: 20 }, (_, i) => (
+                      <div
+                        key={i}
+                        className={`h-8 w-1 ${
+                          Math.random() > 0.5
+                            ? "bg-black dark:bg-white"
+                            : "bg-gray-300 dark:bg-gray-500"
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <div className="text-xs text-gray-600 dark:text-gray-400 font-mono">
+                    {selectedReward.rewardLogId.toString().padStart(8, "0")}
+                  </div>
                 </div>
+
+                {/* 보상 정보 */}
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg shadow-sm">
+                    <span className="text-sm text-gray-600 dark:text-gray-400">발급일</span>
+                    <span className="text-sm font-medium text-gray-900 dark:text-white">
+                      {new Date(selectedReward.receivedAt).toLocaleDateString("ko-KR", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg shadow-sm">
+                    <span className="text-sm text-gray-600 dark:text-gray-400">발급시간</span>
+                    <span className="text-sm font-medium text-gray-900 dark:text-white">
+                      {new Date(selectedReward.receivedAt).toLocaleTimeString("ko-KR", {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg shadow-sm">
+                    <span className="text-sm text-gray-600 dark:text-gray-400">상태</span>
+                    <span
+                      className={`text-sm font-medium ${
+                        selectedReward.used
+                          ? "text-green-600 dark:text-green-400"
+                          : "text-yellow-600 dark:text-yellow-400"
+                      }`}
+                    >
+                      {selectedReward.used ? "사용완료" : "사용가능"}
+                    </span>
+                  </div>
+                </div>
+
+                {/* 사용완료 표시 */}
                 {selectedReward.used && (
-                  <div className="flex items-center justify-center gap-2 text-green-600 font-medium">
-                    <CheckCircle className="w-5 h-5" />
-                    보상완료!
+                  <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg text-center shadow-sm">
+                    <div className="flex items-center justify-center gap-2 text-green-600 dark:text-green-400">
+                      <CheckCircle className="w-5 h-5" />
+                      <span className="font-medium">보상 사용이 완료되었습니다!</span>
+                    </div>
+                  </div>
+                )}
+
+                {/* 사용완료 버튼 */}
+                {!selectedReward.used && (
+                  <div className="mt-6">
+                    <Button
+                      onClick={handleUseReward}
+                      className="w-full bg-gradient-to-b from-blue-100 to-blue-50 hover:from-blue-200 hover:to-blue-100 text-gray-800 dark:text-white font-medium py-3 rounded-lg   dark:border-gray-600"
+                      disabled={isMarking}
+                    >
+                      {isMarking ? (
+                        <div className="flex items-center gap-2">
+                          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-600 dark:border-white"></div>
+                          처리 중...
+                        </div>
+                      ) : (
+                        "보상 사용하기"
+                      )}
+                    </Button>
+                  </div>
+                )}
+
+                {/* 사용 안내 */}
+                {!selectedReward.used && (
+                  <div className="mt-3 text-center">
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      사용하기 버튼을 누르면 보상이 사용완료 처리됩니다
+                    </p>
                   </div>
                 )}
               </div>
-
-              {!selectedReward.used && (
-                <Button
-                  onClick={handleUseReward}
-                  className="w-full bg-green-600 hover:bg-green-700"
-                  disabled={isMarking}
-                >
-                  {isMarking ? "처리 중..." : "사용완료"}
-                </Button>
-              )}
             </div>
           )}
         </DialogContent>

--- a/components/family-space/RewardHistorySection.tsx
+++ b/components/family-space/RewardHistorySection.tsx
@@ -24,7 +24,7 @@ export function RewardHistorySection() {
 
   const handleUseReward = () => {
     if (selectedReward && !selectedReward.used) {
-      markRewardAsUsed(selectedReward.id, {
+      markRewardAsUsed(selectedReward.rewardLogId, {
         onSuccess: () => {
           setShowDetailModal(false);
           toast.success(`${selectedReward.rewardName} 보상을 사용완료 처리했습니다! 🎉`);
@@ -108,7 +108,7 @@ export function RewardHistorySection() {
               const isUsed = reward.used;
               return (
                 <motion.div
-                  key={reward.id}
+                  key={reward.rewardLogId}
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.1 }}

--- a/hooks/plant/index.ts
+++ b/hooks/plant/index.ts
@@ -5,3 +5,5 @@ export * from "./useRewardHistory";
 export * from "./useAddPoint";
 export * from "./useNutrientStock";
 export * from "./useCheckTodayActivity";
+export * from "./useFamilyRewardHistory";
+export * from "./useMarkRewardAsUsed";

--- a/hooks/plant/useFamilyRewardHistory.ts
+++ b/hooks/plant/useFamilyRewardHistory.ts
@@ -1,0 +1,10 @@
+import { plantApi } from "@/lib/api/plant";
+import { useQuery } from "@tanstack/react-query";
+
+export const useFamilyRewardHistory = () => {
+  return useQuery({
+    queryKey: ["reward", "family-history"],
+    queryFn: () => plantApi.getFamilyRewardHistory(),
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/hooks/plant/useMarkRewardAsUsed.ts
+++ b/hooks/plant/useMarkRewardAsUsed.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { plantApi } from "@/lib/api/plant";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const useMarkRewardAsUsed = () => {
   const queryClient = useQueryClient();

--- a/hooks/plant/useMarkRewardAsUsed.ts
+++ b/hooks/plant/useMarkRewardAsUsed.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { plantApi } from "@/lib/api/plant";
+
+export const useMarkRewardAsUsed = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (rewardLogId: number) => plantApi.markRewardAsUsed(rewardLogId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["reward", "family-history"] });
+    },
+  });
+};

--- a/lib/api/plant.ts
+++ b/lib/api/plant.ts
@@ -51,4 +51,14 @@ export const plantApi = {
     const response = await authenticatedApiClient.get("/nutrients/stock");
     return response.data;
   },
+  // 9. 가족 보상 히스토리 조회
+  getFamilyRewardHistory: async (): Promise<RewardHistory[]> => {
+    const response = await authenticatedApiClient.get("/plants/rewards/family-history");
+    return response.data;
+  },
+
+  // 10. 보상 사용 완료 처리
+  markRewardAsUsed: async (rewardLogId: number): Promise<void> => {
+    await authenticatedApiClient.patch(`/plants/rewards/mark-used/${rewardLogId}`);
+  },
 };

--- a/types/plants.type.ts
+++ b/types/plants.type.ts
@@ -24,7 +24,8 @@ export interface ErrorResponse {
 
 //히스토리 보상에 대한 타입 정의( 보상이름,설명,날짜)
 export interface RewardHistory {
-  id: number;
+  rewardLogId: number;
+  rewardId: number;
   rewardName: string;
   description: string;
   receivedAt: string;


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<h2>📝 작업 내용</h2>

<h3>🔧 API 기능 추가</h3>
<ol>
  <li>
    <strong>가족 보상 히스토리 조회 API</strong><br />
    <ul>
      <li>엔드포인트: <code>GET /plants/rewards/family-history</code></li>
      <li>기존 개인 단위 → 가족 전체 보상 히스토리 반환</li>
      <li>반환 항목: 사용자 이름, 프로필 이미지, 보상명, 설명, 수령일, 사용 여부</li>
    </ul>
  </li>
  <li>
    <strong>보상 사용 완료 처리 API</strong><br />
    <ul>
      <li>엔드포인트: <code>PATCH /plants/rewards/mark-used/{rewardLogId}</code></li>
      <li>보상 사용 시 <code>isUsed = true</code> 처리</li>
      <li>가족 구성원 누구나 보상 사용 가능</li>
    </ul>
  </li>
</ol>

<h3>🎨 UI/UX 개선</h3>
<ol>
  <li>
    <strong>모달 레이아웃 조정</strong><br />
    메시지 카드 레이아웃과 통일되도록 <strong>모달 크기 및 정렬 수정</strong>
  </li>
  <li>
    <strong>히스토리 접기/펼치기 기능</strong><br />
    초기에는 보상 내역 일부만 노출되며, <code>전체 보기/접기</code> 토글 가능
  </li>
  <li>
    <strong>보상 클릭 시 상세 시프티콘 형태로 노출</strong><br />
    보상 카드를 클릭하면 실제 <strong>시프티콘 UI</strong>처럼 세부 정보 팝업 표시 (보상명, 이미지, 설명 포함)
  </li>
  <li>
    <strong>색상 개선</strong><br />
    새싹 키우기 UI와 통일된 색상 팔레트 적용 (예: <code>#81C784</code>, <code>#388E3C</code>)<br />
    사용 완료된 보상은 은은한 회색 톤으로 처리
  </li>
</ol>

<hr />

<h3>🧩 재복구 상황</h3>
<ul>
  <li>
    <strong>🌱 새싹 키우기 만들기 버튼 / 식물 상태에 따른 변화 다시 복구</strong><br />
  </li>
  <li>
    <strong>🌿 새싹 키우기 전체 UI 레이아웃 및 미션 다시 연동</strong><br />
  </li>
</ul>

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 접기 화면 모습(메세지 카드와 동일하게) + 완료처리 시 클릭 x

![스크린샷 2025-06-24 071644](https://github.com/user-attachments/assets/a6ffd36f-822f-4f67-b4e1-724ab3fef271)

2. 보상 처리 ui 변경

![스크린샷 2025-06-24 071655](https://github.com/user-attachments/assets/aac0ba96-c911-4490-8370-1c5681f0f91c)
