### PR TITLE
CHAM-98 설문조사 결과 카카오톡 공유 기능 구현

### DIFF
--- a/components/survey/SurveyResultContent.tsx
+++ b/components/survey/SurveyResultContent.tsx
@@ -32,7 +32,7 @@ import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChevronDown, X, ArrowLeft } from "lucide-react";
+import { ChevronDown, X, ArrowLeft, Share2 } from "lucide-react";
 import { useGetSurveyResult } from "@/hooks/use-survey-result";
 import { bugNameUiMap } from "@/types/survey.type";
 import { planDetails, userTypes, typeImageMap, bugIdToNameMap } from "@/lib/survey-result-data";
@@ -41,6 +41,7 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/component
 import { motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { useFamily } from "@/hooks/family";
+import { useKakaoInit, shareSurveyResult } from "@/hooks/useKakaoShare";
 
 // bugId에 따른 추천 이유 매핑
 const getRecommendationReason = (bugId: number): string => {
@@ -68,6 +69,8 @@ export default function SurveyResultContent() {
   const [isAdditionalDiscountOpen, setIsAdditionalDiscountOpen] = useState(false);
   const [isSproutInfoOpen, setIsSproutInfoOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { isLoaded, error } = useKakaoInit(); // Initialize Kakao SDK
+  const [isSharing, setIsSharing] = useState(false);
 
   // URL에서 bugId 가져오기
   const searchParams = useSearchParams();
@@ -129,6 +132,23 @@ export default function SurveyResultContent() {
   };
 
   const recommendationReason = getRecommendationReason(bugId);
+
+  const handleShare = async () => {
+    if (!isLoaded) {
+      alert('공유하기 기능을 불러오는 중입니다. 잠시만 기다려주세요.');
+      return;
+    }
+
+    try {
+      setIsSharing(true);
+      await shareSurveyResult(bugId!, displayName);
+    } catch (error) {
+      console.error('Failed to share:', error);
+      alert('공유하기에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setIsSharing(false);
+    }
+  };
 
   return (
     <div className="bg-gradient-to-b from-blue-100 to-blue-50 min-h-screen w-full">
@@ -362,6 +382,22 @@ export default function SurveyResultContent() {
               className="w-full !bg-[#53a2f5] hover:!bg-[#3069a6] text-white py-4 rounded-2xl text-base shadow-lg hover:shadow-xl transform hover:scale-[1.02] transition-all duration-300"
             >
               요금제 추천 보고 포인트 받기
+            </Button>
+          </div>
+          
+          {/* 카카오톡 공유 버튼 */}
+          <div className="flex justify-center mt-8 mb-12">
+            <Button
+              onClick={handleShare}
+              disabled={!isLoaded || isSharing}
+              className="bg-[#FEE500] hover:bg-[#FEE500]/90 text-black flex items-center gap-2 px-6 py-2 rounded-full shadow-md disabled:opacity-50"
+            >
+              {isSharing ? (
+                <div className="w-5 h-5 border-2 border-black border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <Share2 className="w-5 h-5" />
+              )}
+              {isSharing ? '공유하는 중...' : '카카오톡으로 공유하기'}
             </Button>
           </div>
         </div>

--- a/hooks/useKakaoShare.ts
+++ b/hooks/useKakaoShare.ts
@@ -1,4 +1,5 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { typeImageMap, bugIdToNameMap } from '@/lib/survey-result-data'
 
 declare global {
   interface Window {
@@ -6,12 +7,54 @@ declare global {
   }
 }
 
-export function useKakaoInit() {
-  useEffect(() => {
-    if (typeof window !== 'undefined' && window.Kakao && !window.Kakao.isInitialized()) {
-      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY)
+// SDK 로드 상태를 추적하는 전역 변수
+let isSDKLoaded = false;
+
+// SDK 로드 및 초기화를 처리하는 함수
+const initializeKakao = () => {
+  return new Promise<void>((resolve, reject) => {
+    if (typeof window === 'undefined') {
+      reject(new Error('Window is not defined'));
+      return;
     }
-  }, [])
+
+    if (window.Kakao && isSDKLoaded) {
+      resolve();
+      return;
+    }
+
+    // SDK가 이미 로드되어 있는 경우
+    if (window.Kakao && !isSDKLoaded) {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+      isSDKLoaded = true;
+      resolve();
+      return;
+    }
+
+    // SDK 로드 시도
+    const script = document.createElement('script');
+    script.src = 'https://developers.kakao.com/sdk/js/kakao.js';
+    script.onload = () => {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+      isSDKLoaded = true;
+      resolve();
+    };
+    script.onerror = () => reject(new Error('Failed to load Kakao SDK'));
+    document.head.appendChild(script);
+  });
+};
+
+export function useKakaoInit() {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    initializeKakao()
+      .then(() => setIsLoaded(true))
+      .catch((err) => setError(err));
+  }, []);
+
+  return { isLoaded, error };
 }
 
 export function shareKakao(inviteCode: string, familyName: string) {
@@ -39,6 +82,40 @@ export function shareKakao(inviteCode: string, familyName: string) {
         link: {
           mobileWebUrl: 'https://modi.app',
           webUrl: 'https://modi.app',
+        },
+      },
+    ],
+  })
+}
+
+export function shareSurveyResult(bugId: number, userType: string) {
+  if (!window.Kakao || !window.Kakao.isInitialized()) {
+    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY)
+  }
+  
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (typeof window !== 'undefined' ? window.location.origin : 'https://modi.app');
+  // bugId에 해당하는 이미지 가져오기
+  const bugName = bugIdToNameMap[bugId] || '호박벌형';
+  const imageUrl = `${baseUrl}${typeImageMap[bugName]}`;
+  const shareUrl = `${baseUrl}/survey-result?bugId=${bugId}`;
+
+  window.Kakao.Link.sendDefault({
+    objectType: 'feed',
+    content: {
+      title: `💚 내 성향테스트 결과는?! ${userType}!`,
+      description: '내 성향이 궁금하다면 MDOi에서 테스트해보세요!',
+      imageUrl: imageUrl,
+      link: {
+        mobileWebUrl: shareUrl,
+        webUrl: shareUrl,
+      },
+    },
+    buttons: [
+      {
+        title: 'MODi에서 확인',
+        link: {
+          mobileWebUrl: shareUrl,
+          webUrl: shareUrl,
         },
       },
     ],


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
사용자가 설문조사 결과를 카카오톡으로 공유할 수 있는 기능 추가
결과 페이지 하단에 카카오톡 공유 버튼을 배치하여, 사용자가 자신의 통신 성향 테스트 결과를 쉽게 공유할 수 있음.

1. 카카오톡 공유 버튼 추가
   - 설문조사 결과 페이지 하단에 카카오톡 공유 버튼 배치

2. 공유 메시지 구성
   - 제목: "내 성향테스트 결과는?! [유형]!"
   - 설명: "내 성향이 궁금하다면 MDOi에서 테스트해보세요!"
   - 버튼: "MODi에서 확인"
   - 각 유형별 캐릭터 이미지 표시 (호박벌, 무당벌레, 라바, 나비, 개미)

3. 공유 링크 기능
   - 결과 페이지 URL에 bugId 파라미터 포함
   - 공유 받은 사용자가 링크 클릭 시 해당 결과 페이지로 이동

###  구현 상세
1. Kakao SDK 초기화 및 설정
   - `_document.tsx`에 Kakao SDK 스크립트 추가
   - `useKakaoInit` 훅을 통한 SDK 초기화 관리

2. 공유 기능 구현
   - `useKakaoShare.ts`에 공유 관련 함수 구현
   - bugId 기반의 이미지 매핑 로직 구현
   - 공유 메시지 템플릿 구성

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 설문조사 완료 후 결과 페이지 접속
2. 페이지 하단의 카카오톡 공유하기 버튼 클릭
3. 다음 사항 확인:
   - 카카오톡 공유 메시지가 정상적으로 열리는지
   - 유형별 캐릭터 이미지가 올바르게 표시되는지
   - 공유된 링크를 통해 결과 페이지로 정상 이동되는지
<img width="380" alt="KakaoTalk_Snapshot_20250624_140809" src="https://github.com/user-attachments/assets/48bc244a-968d-4a13-8e92-848403224cc8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a KakaoTalk sharing button to survey results, allowing users to share their results directly via KakaoTalk.
  - The share button displays a loading spinner during the sharing process and is disabled while loading or sharing.

- **Bug Fixes**
  - Improved KakaoTalk SDK loading and error handling to ensure a smoother sharing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->