### PR TITLE
CHAM-100 FEAT: 사용자가 챗봇 사용 시 추천 키워드를 input 상단에 출력

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -60,6 +60,7 @@ export default function ChatPage() {
         familyMode={familyMode}
         familySize={memberCount || 1}
         familySessionId={familySessionId}
+        messages={messages}
       />
     </Fragment>
   );

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -8,6 +8,7 @@ import SttButton from './SttButton';
 import { ClientMessage } from '@/types/chat.type';
 import { useChatStream } from '@/hooks/useChatStream';
 import { v4 as uuidv4 } from 'uuid'
+import SuggestedKeywords from './SuggestedKeywords';
 
 interface ChatInputProps {
   sessionId: string;
@@ -15,8 +16,24 @@ interface ChatInputProps {
   familyMode: boolean;
   familySize: number;
   familySessionId: string;
+  messages: ClientMessage[];
 }
-const ChatInput = ({ sessionId, setMessages, familyMode, familySize, familySessionId }: ChatInputProps) => {
+
+const KEYWORDS = [
+  '저렴한 요금제',
+  '데이터 무제한',
+  '가성비 좋은',
+  '혜택이 많은',
+  '알뜰폰 요금제',
+  '다양한 요금제',
+];
+
+function getRandomKeywords() {
+  const shuffled = [...KEYWORDS].sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, 3);
+}
+
+const ChatInput = ({ sessionId, setMessages, familyMode, familySize, familySessionId, messages }: ChatInputProps) => {
   const [message, setMessage] = useState('');
   const {
     isListening,
@@ -30,6 +47,11 @@ const ChatInput = ({ sessionId, setMessages, familyMode, familySize, familySessi
 
   // 이 ref 에 새로 추가한 AI placeholder 메시지의 id 를 저장
   const aiMessageIdRef = useRef<string | null>(null)
+
+  // 사용자가 첫 메시지를 보냈는지 여부
+  const [hasSentFirst, setHasSentFirst] = useState(false);
+  // 추천 키워드 3개 (초기값 빈 배열)
+  const [suggestedKeywords, setSuggestedKeywords] = useState<string[]>([]);
 
   // 사용자가 전송 버튼 클릭했을 때
   const handleSend = () => {
@@ -59,6 +81,7 @@ const ChatInput = ({ sessionId, setMessages, familyMode, familySize, familySessi
     // 3) 스트리밍 시작
     start(message, familyMode ? familySessionId : sessionId, familyMode ? familySize : 1)
     setMessage('')
+    setSuggestedKeywords(getRandomKeywords()); // 메시지 보낼 때만 키워드 생성
   }
 
   // aiChunk가 갱신될 때마다 placeholder 메시지의 content만 업데이트
@@ -89,9 +112,23 @@ const ChatInput = ({ sessionId, setMessages, familyMode, familySize, familySessi
   const handleStop = () => {
     stop()
   }
+
+  // 키워드 버튼 클릭 시 Input에 입력
+  const handleKeywordClick = (keyword: string) => {
+    setMessage(keyword);
+  }
+
+  // 현재 모드의 세션ID에 해당하는 메시지 중 사용자가 보낸 메시지가 1개 이상일 때만 키워드 노출
+  const currentSessionId = familyMode ? familySessionId : sessionId;
+  const hasUserMessagesInCurrentMode = messages.filter(msg => msg.sessionId === currentSessionId && msg.role === 'user').length > 0;
+
   return (
     <div className="w-full max-w-md mx-auto bg-white dark:bg-gray-800 border-t border-gray-100 dark:border-gray-700 flex-shrink-0">
       <div className="p-4">
+        {/* 현재 모드에 사용자가 보낸 메시지가 있을 때만 키워드 추천 노출 */}
+        {hasUserMessagesInCurrentMode && suggestedKeywords.length > 0 && (
+          <SuggestedKeywords keywords={suggestedKeywords} onSelect={handleKeywordClick} />
+        )}
         <div className="flex items-center space-x-3">
           {sttSupported && (
             <SttButton setMessage={setMessage} sessionId={sessionId} />

--- a/components/chat/SuggestedKeywords.tsx
+++ b/components/chat/SuggestedKeywords.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface SuggestedKeywordsProps {
+  keywords: string[];
+  onSelect: (keyword: string) => void;
+}
+
+const SuggestedKeywords: React.FC<SuggestedKeywordsProps> = ({ keywords, onSelect }) => (
+  <div className="flex gap-2 mb-3 justify-start">
+    {keywords.map((kw) => (
+      <button
+        key={kw}
+        type="button"
+        className="px-3 py-1 rounded-full border border-green-400 text-green-700 bg-green-50 hover:bg-green-100 text-sm transition"
+        onClick={() => onSelect(kw)}
+      >
+        {kw}
+      </button>
+    ))}
+  </div>
+);
+
+export default SuggestedKeywords; 


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
사용자가 채팅을 1개 이상 입력 시 랜덤한 키워드 3개를 input 상단에 출력한다.

키워드는 총 6개이며 다음과 같다.

1. 저렴한 요금제
2. 데이터 무제한
3. 가성비 좋은
4. 혜택이 많은
5. 알뜰폰 요금제
6. 다양한 요금제

사용자가 챗봇을 사용할 때 마다 키워드가 랜덤하게 바뀐다.

![image](https://github.com/user-attachments/assets/1db16518-ae9c-48ef-9a62-4d4238d8c56f)

만약 사용자가 다른 모드에서 챗봇을 사용한 기록이 없다면 해당 모드에서는 키워드가 출력되지 않는다.

![image](https://github.com/user-attachments/assets/6469fd16-fcfe-4294-a385-eb4a3cb47bb1)

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 챗봇을 사용한다.
2. 출력된 키워드를 클릭한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced keyword suggestions in the chat input, offering users three recommended keywords after sending a message.
  - Added a new interface for displaying suggested keywords, allowing users to quickly insert them into the chat input by clicking.

- **Enhancements**
  - Chat input now displays keyword suggestions only when there is at least one user message in the current session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->