### PR TITLE
CHAM-119 메시지 카드 UI 개선 및 버그 수정

### DIFF
--- a/components/family-space/MessageCardCreator.tsx
+++ b/components/family-space/MessageCardCreator.tsx
@@ -5,30 +5,31 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent } from "@/components/ui/card";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Plus, Heart, Star, Gift, Coffee, Sun } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { useToast } from "@/components/ui/use-toast";
 import { useMessageCardsManager } from "@/hooks/family";
-
-const cardTemplates = [
-  { id: "heart", icon: Heart, color: "bg-pink-100 text-pink-600", name: "사랑" },
-  { id: "star", icon: Star, color: "bg-yellow-100 text-yellow-600", name: "응원" },
-  { id: "gift", icon: Gift, color: "bg-purple-100 text-purple-600", name: "선물" },
-  { id: "coffee", icon: Coffee, color: "bg-brown-100 text-brown-600", name: "일상" },
-  { id: "sun", icon: Sun, color: "bg-orange-100 text-orange-600", name: "기분" },
-];
+import { Heart, Plus, Star, Sparkles, Flower2, Leaf } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 
 interface MessageCardCreatorProps {
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   onCardCreated?: () => void;
-  trigger?: React.ReactNode;
+  trigger?: React.ReactNode | null;
 }
+
+const cardTemplates = [
+  { id: "heart", name: "하트", icon: Heart, color: "bg-pink-100 text-pink-600" },
+  { id: "star", name: "별", icon: Star, color: "bg-yellow-100 text-yellow-600" },
+  { id: "sparkle", name: "반짝임", icon: Sparkles, color: "bg-purple-100 text-purple-600" },
+  { id: "flower", name: "꽃", icon: Flower2, color: "bg-rose-100 text-rose-600" },
+  { id: "leaf", name: "나뭇잎", icon: Leaf, color: "bg-green-100 text-green-600" },
+];
 
 export function MessageCardCreator({
   isOpen,
@@ -75,9 +76,9 @@ export function MessageCardCreator({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <>
       {!isControlled && trigger !== null && (
-        <DialogTrigger asChild>
+        <button onClick={() => setOpen?.(true)}>
           {trigger || (
             <Button
               size="sm"
@@ -86,100 +87,129 @@ export function MessageCardCreator({
               <Plus className="w-5 h-5" />
             </Button>
           )}
-        </DialogTrigger>
+        </button>
       )}
-      <DialogContent className="max-w-md mx-auto dark:bg-gray-800">
-        <DialogHeader>
-          <DialogTitle className="dark:text-white">메시지 카드 만들기</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4">
-          {/* 템플릿 선택 */}
-          <div>
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
-              카드 템플릿
-            </label>
-            <div className="flex gap-2 flex-wrap">
-              {cardTemplates.map((template) => {
-                const Icon = template.icon;
-                return (
-                  <button
-                    key={template.id}
-                    onClick={() => setSelectedTemplate(template.id)}
-                    className={`p-3 rounded-xl transition-all ${
-                      selectedTemplate === template.id
-                        ? `${template.color} ring-2 ring-offset-2 ring-green-500`
-                        : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
-                    }`}
-                  >
-                    <Icon className="w-5 h-5" />
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* 내용 입력 */}
-          <div>
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
-              내용
-            </label>
-            <Textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="가족에게 전하고 싶은 메시지를 작성하세요"
-              rows={4}
-              className="dark:bg-gray-700 dark:text-white"
-            />
-          </div>
-
-          {/* 미리보기 */}
-          <div>
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
-              미리보기
-            </label>
-            <Card className="dark:bg-gray-700">
-              <CardContent className="p-4">
-                <div className="flex items-center gap-2 mb-2">
-                  {(() => {
-                    const template = cardTemplates.find((t) => t.id === selectedTemplate);
-                    const Icon = template?.icon || Heart;
-                    return (
-                      <Icon
-                        className={`w-5 h-5 ${template?.color.split(" ")[1] || "text-pink-600"}`}
-                      />
-                    );
-                  })()}
-                  <h3 className="font-semibold text-gray-900 dark:text-white">
-                    {cardTemplates.find((t) => t.id === selectedTemplate)?.name || "템플릿"}
-                  </h3>
-                </div>
-                <p className="text-gray-600 dark:text-gray-300 text-sm">
-                  {content || "내용을 입력하세요"}
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* 버튼 */}
-          <div className="flex gap-2">
-            <Button
+      
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* Overlay */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
               onClick={() => setOpen?.(false)}
-              variant="outline"
-              className="flex-1 hover:bg-gray-100 dark:hover:bg-gray-600"
-              disabled={isCreating}
+              className="fixed inset-0 bg-black bg-opacity-30 z-40"
+            />
+            
+            {/* Content */}
+            <motion.div
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+              className="fixed left-0 right-0 bottom-0 z-50 bg-white dark:bg-gray-800 rounded-t-2xl p-6 pt-4 max-w-md mx-auto"
+              style={{ borderRadius: "20px" }}
             >
-              취소
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              className="flex-1 bg-green-500 hover:bg-gray-600 dark:hover:bg-gray-400 text-white"
-              disabled={isCreating}
-            >
-              {isCreating ? "생성 중..." : "생성하기"}
-            </Button>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+              {/* Handle bar */}
+              <div className="w-12 h-1 bg-gray-200 rounded-full mx-auto mb-4" />
+              
+              <div className="text-center mb-4">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  메시지 카드 만들기
+                </h2>
+              </div>
+
+              <div className="space-y-4">
+                {/* 템플릿 선택 */}
+                <div>
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                    카드 템플릿
+                  </label>
+                  <div className="flex gap-2 flex-wrap">
+                    {cardTemplates.map((template) => {
+                      const Icon = template.icon;
+                      return (
+                        <button
+                          key={template.id}
+                          onClick={() => setSelectedTemplate(template.id)}
+                          className={`p-3 rounded-xl transition-all ${
+                            selectedTemplate === template.id
+                              ? `${template.color} ring-2 ring-offset-2 ring-green-500`
+                              : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                          }`}
+                        >
+                          <Icon className="w-5 h-5" />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* 내용 입력 */}
+                <div>
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                    내용
+                  </label>
+                  <Textarea
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                    placeholder="가족에게 전하고 싶은 메시지를 작성하세요"
+                    rows={4}
+                    className="dark:bg-gray-700 dark:text-white"
+                  />
+                </div>
+
+                {/* 미리보기 */}
+                <div>
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                    미리보기
+                  </label>
+                  <Card className="dark:bg-gray-700">
+                    <CardContent className="p-4">
+                      <div className="flex items-center gap-2 mb-2">
+                        {(() => {
+                          const template = cardTemplates.find((t) => t.id === selectedTemplate);
+                          const Icon = template?.icon || Heart;
+                          return (
+                            <Icon
+                              className={`w-5 h-5 ${template?.color.split(" ")[1] || "text-pink-600"}`}
+                            />
+                          );
+                        })()}
+                        <h3 className="font-semibold text-gray-900 dark:text-white">
+                          {cardTemplates.find((t) => t.id === selectedTemplate)?.name || "템플릿"}
+                        </h3>
+                      </div>
+                      <p className="text-gray-600 dark:text-gray-300 text-sm">
+                        {content || "내용을 입력하세요"}
+                      </p>
+                    </CardContent>
+                  </Card>
+                </div>
+
+                {/* 버튼 */}
+                <div className="flex gap-2 pt-4">
+                  <Button
+                    variant="outline"
+                    onClick={() => setOpen?.(false)}
+                    className="flex-1 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={isCreating || !content.trim()}
+                    className="flex-1 bg-[#5bc236] hover:bg-[#4ca52d] text-white"
+                  >
+                    {isCreating ? "생성 중..." : "카드 만들기"}
+                  </Button>
+                </div>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/components/family-space/MessageCardList.tsx
+++ b/components/family-space/MessageCardList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -47,14 +47,13 @@ function CommentCount({ fcid }: { fcid: number }) {
 
 export function MessageCardList() {
   const [selectedCard, setSelectedCard] = useState<MessageCard | null>(null);
+  const [editingCard, setEditingCard] = useState<{ content: string } | null>(null);
   const [newComment, setNewComment] = useState("");
-  const [editingComment, setEditingComment] = useState<{ id: number; content: string } | null>(
-    null
-  );
+  const [editingComment, setEditingComment] = useState<{ id: number; content: string } | null>(null);
   const [showAll, setShowAll] = useState(false);
   const { toast } = useToast();
 
-  const { messageCards, totalCount, isLoading, isDeleting, deleteMessageCard, refetch } =
+  const { messageCards, totalCount, isLoading, isDeleting, deleteMessageCard, updateMessageCard, refetch } =
     useMessageCardsManager();
 
   // 선택된 카드의 댓글 관리
@@ -131,6 +130,44 @@ export function MessageCardList() {
     setNewComment("");
     setEditingComment(null);
   };
+
+  const handleUpdateCard = async () => {
+    if (!editingCard || !selectedCard) return;
+
+    try {
+      await updateMessageCard({
+        fcid: selectedCard.fcid,
+        data: { 
+          content: editingCard.content.trim(),
+          imageType: selectedCard.imageType
+        }
+      });
+      setEditingCard(null);
+      // 카드 목록 새로고침
+      refetch();
+      toast({
+        title: "메시지 카드가 수정되었습니다! ✏️",
+      });
+    } catch (error) {
+      toast({
+        title: "메시지 카드 수정 실패",
+        description: "잠시 후 다시 시도해주세요.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setSelectedCard(null);
+        setEditingCard(null);
+      }
+    };
+
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, []);
 
   if (isLoading) {
     return (
@@ -254,7 +291,10 @@ export function MessageCardList() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              onClick={() => setSelectedCard(null)}
+              onClick={() => {
+                setSelectedCard(null);
+                setEditingCard(null);
+              }}
               className="fixed inset-0 bg-black bg-opacity-30 z-40"
             />
             
@@ -304,7 +344,46 @@ export function MessageCardList() {
 
                 {/* 카드 내용 */}
                 <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-xl">
-                  <p className="text-gray-700 dark:text-gray-300">{selectedCard.content}</p>
+                  {editingCard ? (
+                    <div className="space-y-3">
+                      <Input
+                        value={editingCard.content}
+                        onChange={(e) => setEditingCard({ content: e.target.value })}
+                        placeholder="메시지를 입력하세요..."
+                        className="w-full"
+                      />
+                      <div className="flex gap-2 justify-end">
+                        <Button
+                          variant="outline"
+                          onClick={() => setEditingCard(null)}
+                          className="text-sm"
+                        >
+                          취소
+                        </Button>
+                        <Button
+                          onClick={handleUpdateCard}
+                          disabled={!editingCard.content.trim()}
+                          className="bg-[#5bc236] hover:bg-[#4ca52d] text-white text-sm"
+                        >
+                          수정
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-gray-700 dark:text-gray-300 flex-1">{selectedCard.content}</p>
+                      {selectedCard.canDelete && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-auto p-1 text-gray-500 hover:text-gray-700"
+                          onClick={() => setEditingCard({ content: selectedCard.content })}
+                        >
+                          <Edit className="w-4 h-4" />
+                        </Button>
+                      )}
+                    </div>
+                  )}
                 </div>
 
                 {/* 댓글 목록 */}
@@ -333,7 +412,7 @@ export function MessageCardList() {
                     <Button
                       onClick={handleAddComment}
                       disabled={!newComment.trim() || commentsManager.isCreating}
-                      className="bg-green-500 hover:bg-green-600 text-white"
+                      className="bg-[#5bc236] hover:bg-green-600 text-white"
                     >
                       {commentsManager.isCreating ? "..." : "작성"}
                     </Button>
@@ -359,20 +438,69 @@ export function MessageCardList() {
                                 {new Date(comment.createdAt).toLocaleDateString("ko-KR")}
                               </span>
                               {comment.canDelete && (
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="h-auto p-1 text-red-500 hover:text-red-700"
-                                  onClick={() => handleDeleteComment(comment.commentId)}
-                                >
-                                  <Trash2 className="w-3 h-3" />
-                                </Button>
+                                <div className="flex items-center gap-1">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-auto p-1 text-gray-500 hover:text-gray-700"
+                                    onClick={() => setEditingComment({ id: comment.commentId, content: comment.content })}
+                                  >
+                                    <Edit className="w-3 h-3" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-auto p-1 text-red-500 hover:text-red-700"
+                                    onClick={() => handleDeleteComment(comment.commentId)}
+                                  >
+                                    <Trash2 className="w-3 h-3" />
+                                  </Button>
+                                </div>
                               )}
                             </div>
                           </div>
-                          <p className="text-gray-700 dark:text-gray-300 break-words">
-                            {comment.content}
-                          </p>
+                          {editingComment?.id === comment.commentId ? (
+                            <div className="mt-2">
+                              <div className="relative">
+                                <Input
+                                  value={editingComment.content}
+                                  onChange={(e) =>
+                                    setEditingComment((prev) => (prev ? { ...prev, content: e.target.value } : null))
+                                  }
+                                  placeholder="댓글을 입력하세요..."
+                                  className="pr-[140px]"
+                                  onKeyPress={(e) => {
+                                    if (e.key === "Enter" && !e.shiftKey) {
+                                      e.preventDefault();
+                                      handleUpdateComment();
+                                    }
+                                  }}
+                                />
+                                <div className="absolute right-1 top-1 flex items-center gap-1">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setEditingComment(null)}
+                                    className="h-7 text-xs px-2"
+                                  >
+                                    취소
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    onClick={handleUpdateComment}
+                                    disabled={!editingComment.content.trim()}
+                                    className="h-7 text-xs px-2 bg-[#5bc236] hover:bg-[#4ca52d] text-white"
+                                  >
+                                    수정
+                                  </Button>
+                                </div>
+                              </div>
+                            </div>
+                          ) : (
+                            <p className="text-gray-700 dark:text-gray-300 break-words">
+                              {comment.content}
+                            </p>
+                          )}
                         </div>
                       </div>
                     ))}
@@ -383,41 +511,6 @@ export function MessageCardList() {
           </>
         )}
       </AnimatePresence>
-
-      {/* 댓글 수정 모달 */}
-      <Dialog open={!!editingComment} onOpenChange={() => setEditingComment(null)}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>댓글 수정</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <Input
-              value={editingComment?.content || ""}
-              onChange={(e) =>
-                setEditingComment((prev) => (prev ? { ...prev, content: e.target.value } : null))
-              }
-              placeholder="댓글을 입력하세요..."
-              className="dark:bg-gray-700 dark:text-white"
-              onKeyPress={(e) => e.key === "Enter" && handleUpdateComment()}
-            />
-            <div className="flex gap-2 justify-end">
-              <Button
-                variant="outline"
-                onClick={() => setEditingComment(null)}
-                disabled={commentsManager.isUpdating}
-              >
-                취소
-              </Button>
-              <Button
-                onClick={handleUpdateComment}
-                disabled={commentsManager.isUpdating || !editingComment?.content.trim()}
-              >
-                수정
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
     </>
   );
 }

--- a/components/family-space/MessageCardList.tsx
+++ b/components/family-space/MessageCardList.tsx
@@ -24,6 +24,12 @@ import { MessageCardComment } from "@/types/message-card.type";
 import Image from "next/image";
 import { useMessageCardCommentCount } from "@/hooks/family/useFamilyQueries";
 import { motion, AnimatePresence } from "framer-motion";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 const cardTemplates = [
   { id: "heart", icon: Heart, color: "bg-pink-100 text-pink-600", name: "사랑" },
@@ -240,13 +246,35 @@ export function MessageCardList() {
       )}
 
       {/* 카드 상세 모달 */}
-      <Dialog open={!!selectedCard} onOpenChange={() => setSelectedCard(null)}>
-        <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto">
-          {selectedCard && (
-            <>
-              <DialogHeader>
-                <DialogTitle className="text-center">메시지 카드</DialogTitle>
-              </DialogHeader>
+      <AnimatePresence>
+        {selectedCard && (
+          <>
+            {/* Overlay */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setSelectedCard(null)}
+              className="fixed inset-0 bg-black bg-opacity-30 z-40"
+            />
+            
+            {/* Content */}
+            <motion.div
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+              className="fixed left-0 right-0 bottom-0 z-50 bg-white dark:bg-gray-800 rounded-t-2xl p-6 pt-4 max-w-md mx-auto"
+              style={{ borderRadius: "20px" }}
+            >
+              {/* Handle bar */}
+              <div className="w-12 h-1 bg-gray-200 rounded-full mx-auto mb-4" />
+              
+              <div className="text-center mb-4">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  메시지 카드
+                </h2>
+              </div>
 
               <div className="space-y-4">
                 {/* 작성자 정보 */}
@@ -280,115 +308,81 @@ export function MessageCardList() {
                 </div>
 
                 {/* 댓글 목록 */}
-                <div>
-                  <h4 className="font-medium text-gray-900 dark:text-white mb-3">
-                    댓글 ({commentsManager.totalCount})
-                  </h4>
-                  <div className="space-y-3 max-h-40 overflow-y-auto">
-                    {commentsManager.isLoading ? (
-                      <div className="text-center py-4">
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-green-500 mx-auto"></div>
-                      </div>
-                    ) : commentsManager.comments.length > 0 ? (
-                      commentsManager.comments.map((comment) => (
-                        <div
-                          key={comment.commentId}
-                          className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg"
-                        >
-                          <div className="flex items-start justify-between gap-2">
-                            <div className="flex items-center gap-2 mb-2">
-                              {comment.authorProfileImage ? (
-                                <Image
-                                  src={comment.authorProfileImage}
-                                  alt={`${comment.authorName}의 프로필`}
-                                  width={24}
-                                  height={24}
-                                  className="w-6 h-6 rounded-full object-cover"
-                                />
-                              ) : (
-                                <div className="w-6 h-6 bg-gray-300 rounded-full flex items-center justify-center text-xs">
-                                  {comment.authorName.charAt(0)}
-                                </div>
-                              )}
-                              <span className="text-sm font-medium text-gray-900 dark:text-white">
-                                {comment.authorName}
-                              </span>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium text-gray-900 dark:text-white">댓글</h3>
+                    <span className="text-sm text-gray-500">
+                      {commentsManager.comments.length}개의 댓글
+                    </span>
+                  </div>
+
+                  {/* 댓글 입력 */}
+                  <div className="flex gap-2">
+                    <Input
+                      value={newComment}
+                      onChange={(e) => setNewComment(e.target.value)}
+                      placeholder="댓글을 입력하세요..."
+                      className="flex-1"
+                      onKeyPress={(e) => {
+                        if (e.key === "Enter" && !e.shiftKey) {
+                          e.preventDefault();
+                          handleAddComment();
+                        }
+                      }}
+                    />
+                    <Button
+                      onClick={handleAddComment}
+                      disabled={!newComment.trim() || commentsManager.isCreating}
+                      className="bg-green-500 hover:bg-green-600 text-white"
+                    >
+                      {commentsManager.isCreating ? "..." : "작성"}
+                    </Button>
+                  </div>
+
+                  {/* 댓글 목록 */}
+                  <div className="space-y-3 max-h-[40vh] overflow-y-auto">
+                    {commentsManager.comments.map((comment) => (
+                      <div
+                        key={comment.commentId}
+                        className="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
+                      >
+                        <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-sm">
+                          {comment.authorName.charAt(0)}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="font-medium text-gray-900 dark:text-white">
+                              {comment.authorName}
+                            </p>
+                            <div className="flex items-center gap-2">
                               <span className="text-xs text-gray-400">
                                 {new Date(comment.createdAt).toLocaleDateString("ko-KR")}
                               </span>
-                            </div>
-                            <div className="flex items-center gap-1">
-                              {comment.canModify && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  className="p-1 h-auto"
-                                  onClick={() =>
-                                    setEditingComment({
-                                      id: comment.commentId,
-                                      content: comment.content,
-                                    })
-                                  }
-                                >
-                                  <Edit className="w-3 h-3" />
-                                </Button>
-                              )}
                               {comment.canDelete && (
                                 <Button
-                                  size="sm"
                                   variant="ghost"
-                                  className="p-1 h-auto text-red-500 hover:text-red-700"
+                                  size="sm"
+                                  className="h-auto p-1 text-red-500 hover:text-red-700"
                                   onClick={() => handleDeleteComment(comment.commentId)}
-                                  disabled={commentsManager.isDeleting}
                                 >
                                   <Trash2 className="w-3 h-3" />
                                 </Button>
                               )}
                             </div>
                           </div>
-                          <p className="text-sm text-gray-700 dark:text-gray-300">
+                          <p className="text-gray-700 dark:text-gray-300 break-words">
                             {comment.content}
                           </p>
                         </div>
-                      ))
-                    ) : (
-                      <div className="text-center py-4 text-gray-500 dark:text-gray-400">
-                        아직 댓글이 없어요
                       </div>
-                    )}
+                    ))}
                   </div>
                 </div>
-
-                {/* 댓글 입력 */}
-                <div className="flex gap-2">
-                  <Input
-                    value={newComment}
-                    onChange={(e) => setNewComment(e.target.value)}
-                    placeholder="댓글을 입력하세요..."
-                    className="flex-1 dark:bg-gray-700 dark:text-white"
-                    onKeyPress={(e) =>
-                      e.key === "Enter" && !commentsManager.isCreating && handleAddComment()
-                    }
-                    disabled={commentsManager.isCreating}
-                  />
-                  <Button
-                    onClick={handleAddComment}
-                    size="icon"
-                    className="bg-green-500 hover:bg-green-600"
-                    disabled={commentsManager.isCreating || !newComment.trim()}
-                  >
-                    {commentsManager.isCreating ? (
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                    ) : (
-                      <Send className="w-4 h-4" />
-                    )}
-                  </Button>
-                </div>
               </div>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
 
       {/* 댓글 수정 모달 */}
       <Dialog open={!!editingComment} onOpenChange={() => setEditingComment(null)}>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
1. 메시지 카드 UI를 카카오톡 초대 코드 공유 모달과 동일한 스타일로 변경
   - 바텀 시트 스타일 적용
   - 모달 너비를 28rem(max-w-md)으로 통일

2. 메시지 카드 수정/삭제 기능 개선
   - 메시지 카드 수정 기능 복구
   - 댓글 수정 기능 복구
   - 모달 닫을 때 수정 상태 초기화 버그 수정 (오버레이 클릭, ESC 키)

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 메시지 카드 생성/수정/삭제 기능 테스트
   - 메시지 카드 생성 확인
   - 메시지 카드 수정 후 모달 닫고 다른 카드 열어서 수정 상태 초기화 확인
   - 메시지 카드 삭제 확인

2. 댓글 기능 테스트
   - 댓글 작성 확인
   - 댓글 수정 확인
   - 댓글 삭제 확인

3. UI 테스트
   - 모든 모달이 동일한 너비(28rem)로 표시되는지 확인
   - 모든 버튼이 동일한 색상(#5bc236)으로 표시되는지 확인
<img width="358" alt="스크린샷 2025-06-26 오전 2 06 14" src="https://github.com/user-attachments/assets/2d983ca9-a872-4eeb-a93c-2a3a3282919f" />
<img width="358" alt="스크린샷 2025-06-26 오전 2 06 23" src="https://github.com/user-attachments/assets/4f68e0bd-ad03-4220-a4a5-2e4406118a76" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced animated bottom sheet panels for creating and editing message cards, replacing previous modal dialogs.
  - Added inline editing for both message cards and comments within the bottom sheet interface.
  - Enabled keyboard Escape key to close sheets and cancel editing actions.

- **UI Improvements**
  - Updated card template icons and simplified template names.
  - Enhanced comment section layout with improved spacing, grouped action buttons, and avatar placeholders.
  - Adjusted button styles and disabled states for better feedback and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->